### PR TITLE
fix(mac): Fix truncated config prompts for mac os

### DIFF
--- a/git_delete_merged_branches/_multiselect.py
+++ b/git_delete_merged_branches/_multiselect.py
@@ -306,9 +306,7 @@ class _MultiSelectPrompt:
         buffer = Buffer(read_only=True, document=document)
         buffer_control = BufferControl(
             buffer=buffer, input_processors=[_NonItemRenderProcessor(prompt=self, lines=lines)])
-        return Window(buffer_control,
-                      wrap_lines=True,
-                      height=Dimension(min=len(lines), max=len(lines)))
+        return Window(buffer_control, wrap_lines=True, height=Dimension(min=len(lines)))
 
     def _create_layout(self) -> Tuple[Layout, _HeightTrackingScrollablePane]:
         header = self._create_text_display_window_for(self._header_lines)


### PR DESCRIPTION
This change removes the `max` dimension from the prompt-toolkit windows used during configuration.  While the windows enabled the text to wrap, the max was set to the number of lines, so when the text had to wrap the previous lines ended up "scrolled" off the top of the window.

This should fix issue #94