### PR TITLE
`run-tests.yml`: Replace call to `python3 setup.py test` with pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,5 +24,7 @@ jobs:
       run: |
         set -x
         python3 --version
-        pip3 install -U setuptools  # for Python >=3.12
-        python3 setup.py test
+        pip3 install -U pip setuptools wheel
+        pip3 install ".[tests]"  # for test dependencies
+        pip3 install -U pytest  # for a test runner
+        exec pytest -v -Wdefault -Werror


### PR DESCRIPTION
.. because Setuptools >=72 stopped providing that command:

https://setuptools.pypa.io/en/stable/history.html#v72-0-0

CC https://github.com/hartwork/resolve-march-native/pull/170