### PR TITLE
Be robust towards `git branch` column output

### DIFF
--- a/git_delete_merged_branches/_git.py
+++ b/git_delete_merged_branches/_git.py
@@ -109,6 +109,8 @@ class Git:
         # strip_left==2 strips leading "refs/heads/" and "refs/remotes/"
         argv = [
             self._GIT,
+            "-c",
+            "column.branch=plain",
             "branch",
             f"--format=%(refname:lstrip={strip_left})",
         ]


### PR DESCRIPTION
In reaction to https://github.com/hartwork/git-delete-merged-branches/issues/159#issuecomment-2704785241