### PR TITLE
feat: add --exclude-regex flag (closes #120)

### DIFF
--- a/git_delete_merged_branches/_cli.py
+++ b/git_delete_merged_branches/_cli.py
@@ -133,6 +133,20 @@ def _parse_command_line(colorize: bool, args=None):
             ', then acts in logical conjunction ("and")'
         ),
     )
+    scope.add_argument(
+        "--exclude-regex",
+        metavar="PATTERN",
+        dest="excluded_branches_patterns",
+        default=[],
+        action="append",
+        help=(
+            "exclude branches from deletion that match the given"
+            ' regular expression (e.g. "^release-")'
+            '; syntax is that of Python module "re"'
+            "; can be passed multiple times"
+            ', then acts in logical conjunction ("and")'
+        ),
+    )
 
     switches = parser.add_argument_group("flags")
     switches.add_argument(
@@ -175,7 +189,10 @@ def _innermost_main(config, messenger, colorize: bool):
         git_config, config.required_target_branches
     )
     excluded_branches = dmb.determine_excluded_branches(
-        git_config, config.excluded_branches, config.included_branches_patterns
+        git_config,
+        config.excluded_branches,
+        config.included_branches_patterns,
+        config.excluded_branches_patterns,
     )
     enabled_remotes = dmb.determine_enabled_remotes(git_config, config.enabled_remotes)
 

--- a/git_delete_merged_branches/_engine.py
+++ b/git_delete_merged_branches/_engine.py
@@ -537,7 +537,11 @@ class DeleteMergedBranches:
             )
 
     def determine_excluded_branches(
-        self, git_config: dict, excluded_branches: list[str], included_branches_patterns: list[str]
+        self,
+        git_config: dict,
+        excluded_branches: list[str],
+        included_branches_patterns: list[str],
+        excluded_branches_patterns: list[str] = [],
     ) -> set[str]:
         existing_branches = set(self._git.find_all_branch_names())
         if excluded_branches:
@@ -563,6 +567,17 @@ class DeleteMergedBranches:
                 if matcher.search(branch_name):
                     continue
                 excluded_branches_set.add(branch_name)
+
+        # Exclude branches matching any of the exclusion patterns
+        for excluded_branches_pattern in excluded_branches_patterns:
+            try:
+                matcher = re.compile(excluded_branches_pattern)
+            except re.error:
+                raise _InvalidRegexPattern(excluded_branches_pattern)
+
+            for branch_name in existing_branches:
+                if matcher.search(branch_name):
+                    excluded_branches_set.add(branch_name)
 
         return excluded_branches_set
 


### PR DESCRIPTION
Closes #120

Adds `--exclude-regex PATTERN` argument that excludes branches matching the given regex from deletion. Works inversely to `--include-regex`.

Example usage:
```bash
git-dmb --exclude-regex "^release-" --exclude-regex "^hotfix-"
```

Can be passed multiple times, acts in logical conjunction ("and").