### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         args:
           - --fix
       - id: ruff-format
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
+    hooks:
+      - id: codespell
+        args: ["--check-hidden"]

--- a/git_delete_merged_branches/_without.py
+++ b/git_delete_merged_branches/_without.py
@@ -7,7 +7,7 @@ from typing import Any
 
 def without(needle: list[Any], container: list[Any]) -> list[Any]:
     """
-    Create a copy of a list with all occurences of sublist ``needle`` removed.
+    Create a copy of a list with all occurrences of sublist ``needle`` removed.
     """
     if not needle:
         return copy.copy(container)


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.